### PR TITLE
Proposed fix for cpants error:

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -38,7 +38,7 @@ EOW
 WriteMakefile( NAME => 'Net::OpenSSH',
                VERSION_FROM => 'lib/Net/OpenSSH.pm',
                ABSTRACT_FROM => 'lib/Net/OpenSSH.pm',
-               PREREQ_PM => { Test::More => 0, },
+               PREREQ_PM => { Test::More => 0, Moo => 0 },
                AUTHOR => 'Salvador Fandino <sfandino@yahoo.com>',
                META_MERGE => {
                    resources => {

--- a/lib/Net/OpenSSH/ConnectionCache.pm
+++ b/lib/Net/OpenSSH/ConnectionCache.pm
@@ -1,5 +1,6 @@
 package Net::OpenSSH::ConnectionCache;
 
+use strict; use warnings;
 use Net::OpenSSH;
 use Net::OpenSSH::Constants qw(:error);
 

--- a/lib/Net/OpenSSH/SSH.pm
+++ b/lib/Net/OpenSSH/SSH.pm
@@ -1,5 +1,7 @@
 package Net::OpenSSH::SSH;
 
+use strict; use warnings;
+
 1;
 
 __END__


### PR DESCRIPTION
Hi,

Please review the following changes for CPANTS error as mentioned below:
http://cpants.cpanauthors.org/dist/Net-OpenSSH/errors

- Added missing prereqs package Moo.
- Added missing 'use strict; use warnings' in the package Net::OpenSSH::SSH 
  and Net::OpenSSH::ConnectorCache.

Many Thanks.

Best Regards,
Mohammad S Anwar