### PR TITLE
Don't modify SIGCHLD handler when using async mode

### DIFF
--- a/lib/Net/OpenSSH.pm
+++ b/lib/Net/OpenSSH.pm
@@ -918,7 +918,7 @@ sub _master_start {
 
     my @call = $self->_make_ssh_call(\@master_opts);
 
-    local $SIG{CHLD};
+    local $SIG{CHLD} unless $async;
     my $pid = fork;
     unless ($pid) {
         defined $pid


### PR DESCRIPTION
- When I am using async mode and the EV event loop, I wasn't being
  notified of process exits via the condition variable returned by
  AnyEvent::Util::run_cmd(... $ssh->make_remote_command ...).

- After applying this patch, I am immediately notified when (for example)
  the ssh connection is lost.

- I believe that the other locations in the file that install SIGCHLD
  handlers would also break EV's child handlers, but this doesn't affect
  my use-case since after the SSH object is constructed I only use
  $ssh->make_remote_command().