### PR TITLE
Fix connection cache eviction

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -18,6 +18,7 @@ lib/Net/OpenSSH/ShellQuoter/MSCmd.pm
 lib/Net/OpenSSH/ShellQuoter/Chain.pm
 lib/Net/OpenSSH/ObjectRemote.pm
 t/common.pm
+t/connection-cache.t
 t/test_server_key
 t/test_server_key.pub
 t/test_user_key

--- a/lib/Net/OpenSSH/ConnectionCache.pm
+++ b/lib/Net/OpenSSH/ConnectionCache.pm
@@ -27,15 +27,15 @@ sub _factory {
         }
     }
     if ($MAX_SIZE <= keys %cache) {
-	for (keys %cache) {
-	    $ssh = $cache{$_};
-	    delete $cache{$_} unless $ssh and $ssh->error != OSSH_MASTER_FAILED;
-	}
-	for (keys %cache) {
-	    last if (keys %cache < $MAX_SIZE);
-	    weaken $cache{$_};
-	    if (defined $cache{$_}) {
-		$cache{$_} = $cache{$_}; # unweaken
+        for (keys %cache) {
+            $ssh = $cache{$_};
+            delete $cache{$_} unless $ssh and $ssh->error != OSSH_MASTER_FAILED;
+        }
+        for (keys %cache) {
+            last if (keys %cache < $MAX_SIZE);
+            weaken $cache{$_};
+            if (defined $cache{$_}) {
+                $cache{$_} = $cache{$_}; # unweaken
             }
             else {
                 delete $cache{$_};

--- a/lib/Net/OpenSSH/ConnectionCache.pm
+++ b/lib/Net/OpenSSH/ConnectionCache.pm
@@ -27,15 +27,15 @@ sub _factory {
         }
     }
     if ($MAX_SIZE <= keys %cache) {
-        for (keys %cache) {
-            $ssh = $cache{$_};
-            $ssh or $ssh->error != OSSH_MASTER_FAILED or delete $cache{$_}
-        }
-        for (keys %cache) {
-            last if ($MAX_SIZE <= keys %cache);
-            weaken $cache{$_};
-            if (defined $cache{$_}) {
-                $cache{$_} = $cache{$_}; # unweaken
+	for (keys %cache) {
+	    $ssh = $cache{$_};
+	    delete $cache{$_} unless $ssh and $ssh->error != OSSH_MASTER_FAILED;
+	}
+	for (keys %cache) {
+	    last if (keys %cache < $MAX_SIZE);
+	    weaken $cache{$_};
+	    if (defined $cache{$_}) {
+		$cache{$_} = $cache{$_}; # unweaken
             }
             else {
                 delete $cache{$_};

--- a/t/connection-cache.t
+++ b/t/connection-cache.t
@@ -40,7 +40,7 @@ ok(!exists $Net::OpenSSH::ConnectionCache::cache{failed}, 'failed master entry i
 ok(!exists $Net::OpenSSH::ConnectionCache::cache{empty}, 'empty cache entry is removed');
 ok(exists $Net::OpenSSH::ConnectionCache::cache{live}, 'live cache entry is retained');
 ok((keys %Net::OpenSSH::ConnectionCache::cache) <= $Net::OpenSSH::ConnectionCache::MAX_SIZE,
-   'cache is reduced below the configured maximum');
+   'cache is reduced to the configured maximum or below');
 
 Net::OpenSSH::ConnectionCache::clean_cache();
 is(scalar keys %Net::OpenSSH::ConnectionCache::cache, 0, 'clean_cache clears cache');

--- a/t/connection-cache.t
+++ b/t/connection-cache.t
@@ -1,0 +1,46 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+
+use Test::More tests => 7;
+use Net::OpenSSH::Constants qw(OSSH_MASTER_FAILED);
+use Net::OpenSSH::ConnectionCache;
+
+{
+    package Test::Net::OpenSSH::ConnectionCache::SSH;
+
+    sub new {
+        my $class = shift;
+        return bless { @_ }, $class;
+    }
+
+    sub error { shift->{error} || 0 }
+    sub wait_for_master { 1 }
+}
+
+local $Net::OpenSSH::ConnectionCache::MAX_SIZE = 2;
+local %Net::OpenSSH::ConnectionCache::cache = (
+    live   => Test::Net::OpenSSH::ConnectionCache::SSH->new(error => 0),
+    failed => Test::Net::OpenSSH::ConnectionCache::SSH->new(error => OSSH_MASTER_FAILED),
+    empty  => undef,
+);
+
+my $ssh;
+eval {
+    $ssh = Net::OpenSSH::ConnectionCache::_factory(
+        'Test::Net::OpenSSH::ConnectionCache::SSH',
+        host => 'cache-test-host'
+    );
+};
+
+is($@, '', 'cache cleanup does not die on empty entries');
+ok($ssh, 'factory returns a new object');
+ok(!exists $Net::OpenSSH::ConnectionCache::cache{failed}, 'failed master entry is removed');
+ok(!exists $Net::OpenSSH::ConnectionCache::cache{empty}, 'empty cache entry is removed');
+ok(exists $Net::OpenSSH::ConnectionCache::cache{live}, 'live cache entry is retained');
+ok((keys %Net::OpenSSH::ConnectionCache::cache) <= $Net::OpenSSH::ConnectionCache::MAX_SIZE,
+   'cache is reduced below the configured maximum');
+
+Net::OpenSSH::ConnectionCache::clean_cache();
+is(scalar keys %Net::OpenSSH::ConnectionCache::cache, 0, 'clean_cache clears cache');


### PR DESCRIPTION
## Summary

Fixes two bugs in `Net::OpenSSH::ConnectionCache`:

- Failed cache entries were never deleted because the cleanup expression short-circuited on any defined object.
- Undef cache entries could cause a method call on undef during cleanup.
- The cache-size eviction loop stopped while the cache was still at or above the configured maximum.

## Changes

- Rewrite failed/undef entry cleanup explicitly.
- Reverse the cache-size stop condition so eviction can run until the cache drops below the limit.
- Add a regression test covering undef, failed, and live cache entries.
- Add the new test file to `MANIFEST`.

Fixes #35.
Fixes #36.

## Testing

- `perl -Ilib -c lib/Net/OpenSSH/ConnectionCache.pm`
- `perl -Ilib t/connection-cache.t`