### PR TITLE
Make Net::OpenSSH::More loadable

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -6,6 +6,7 @@ t/1_run.t
 lib/Net/OpenSSH.pm
 lib/Net/OpenSSH/Constants.pm
 lib/Net/OpenSSH/ConnectionCache.pm
+lib/Net/OpenSSH/More.pm
 lib/Net/OpenSSH/OSTracer.pm
 lib/Net/OpenSSH/ModuleLoader.pm
 lib/Net/OpenSSH/SSH.pm

--- a/MANIFEST
+++ b/MANIFEST
@@ -19,6 +19,7 @@ lib/Net/OpenSSH/ShellQuoter/MSCmd.pm
 lib/Net/OpenSSH/ShellQuoter/Chain.pm
 lib/Net/OpenSSH/ObjectRemote.pm
 t/common.pm
+t/more.t
 t/test_server_key
 t/test_server_key.pub
 t/test_user_key

--- a/lib/Net/OpenSSH/More.pm
+++ b/lib/Net/OpenSSH/More.pm
@@ -1,3 +1,12 @@
+package Net::OpenSSH;
+
+use strict;
+use warnings;
+
+use Net::OpenSSH ();
+
+our $debug;
+
 _sub_options scp_cat => qw(); # stderr_discard stderr_fh stderr_file);
 
 sub scp_cat {
@@ -87,6 +96,8 @@ sub scp_cat {
     wantarray ? ($cat, $pid) : $cat;
 }
 
+1;
+
 =head1 API
 
 =over 4
@@ -123,4 +134,3 @@ prints errors to STDERR
 =head1 BUGS AND SUPPORT
 
 Support for scp_cat is experimental.
-

--- a/t/more.t
+++ b/t/more.t
@@ -1,0 +1,10 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+
+use Test::More tests => 1;
+
+use Net::OpenSSH::More;
+
+ok(Net::OpenSSH->can('scp_cat'), 'Net::OpenSSH::More installs scp_cat');


### PR DESCRIPTION
## Summary

Make `lib/Net/OpenSSH/More.pm` a valid standalone module instead of an installed source fragment.

## Changes

- Declare `package Net::OpenSSH`.
- Enable `strict` and `warnings`.
- Load `Net::OpenSSH` so internal helpers/constants are available.
- Declare the shared package global `$debug` used by the extension.
- Return true from the module.
- Add `More.pm` to `MANIFEST`.

Fixes #37.

## Testing

- `perl -Ilib -c lib/Net/OpenSSH/More.pm`
- `perl -Ilib -MNet::OpenSSH::More -e 'print Net::OpenSSH->can(q(scp_cat)) ? qq(ok\\n) : qq(missing\\n)'`
- `perl -Ilib -c lib/Net/OpenSSH.pm`