### PR TITLE
Harden module loading

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -23,6 +23,7 @@ t/test_server_key.pub
 t/test_user_key
 t/test_user_key.pub
 t/known_hosts
+t/module-loader.t
 t/quoting.t
 t/uri.t
 examples/expect.pl

--- a/lib/Net/OpenSSH/ModuleLoader.pm
+++ b/lib/Net/OpenSSH/ModuleLoader.pm
@@ -11,6 +11,7 @@ our @EXPORT = qw(_load_module);
 
 sub _load_module {
     my ($module, $version) = @_;
+    defined $module or croak "bad Perl module name";
     $module =~ /\A[A-Za-z_]\w*(?:::\w+)*\z/
         or croak "bad Perl module name $module";
     $loaded_module{$module} ||= do {

--- a/lib/Net/OpenSSH/ModuleLoader.pm
+++ b/lib/Net/OpenSSH/ModuleLoader.pm
@@ -11,23 +11,22 @@ our @EXPORT = qw(_load_module);
 
 sub _load_module {
     my ($module, $version) = @_;
+    $module =~ /\A[A-Za-z_]\w*(?:::\w+)*\z/
+        or croak "bad Perl module name $module";
     $loaded_module{$module} ||= do {
         my $err;
         do {
             local ($@, $SIG{__DIE__});
-            my $ok = eval "require $module; 1";
+            (my $path = "$module.pm") =~ s!::!/!g;
+            my $ok = eval { require $path; 1 };
             $err = $@;
             $ok;
         } or croak "unable to load Perl module $module: $err";
     };
     if (defined $version) {
-        my $mv = do {
-            local ($@, $SIG{__DIE__});
-            eval "\$${module}::VERSION";
-        } || 0;
-	(my $mv1 = $mv) =~ s/_\d*$//;
-	croak "$module version $version required, $mv is available"
-	    if $mv1 < $version;
+        local ($@, $SIG{__DIE__});
+        eval { $module->VERSION($version); 1 }
+            or croak $@ || "$module version $version required";
     }
     1
 }

--- a/t/module-loader.t
+++ b/t/module-loader.t
@@ -1,0 +1,31 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+
+use Test::More tests => 5;
+
+use Net::OpenSSH::ModuleLoader;
+
+ok(_load_module('strict'), 'loads a valid module name');
+
+eval { _load_module('strict; die "boom"') };
+like($@, qr/bad Perl module name/, 'rejects unsafe module names');
+
+eval { _load_module('strict', 999_999) };
+like($@, qr/strict version 999999 required|strict version 999999 required--this is only version/,
+     'uses standard VERSION checks for too-new requirements');
+
+{
+    package Test::Net::OpenSSH::ModuleLoader::Versioned;
+    our $VERSION = '1.02';
+}
+
+$INC{'Test/Net/OpenSSH/ModuleLoader/Versioned.pm'} = __FILE__;
+
+ok(_load_module('Test::Net::OpenSSH::ModuleLoader::Versioned', '1.01'),
+   'accepts a sufficient version');
+
+eval { _load_module('Test::Net::OpenSSH::ModuleLoader::Versioned', '1.03') };
+like($@, qr/Test::Net::OpenSSH::ModuleLoader::Versioned version 1.03 required/,
+     'rejects an insufficient version');

--- a/t/module-loader.t
+++ b/t/module-loader.t
@@ -3,7 +3,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 5;
+use Test::More tests => 6;
 
 use Net::OpenSSH::ModuleLoader;
 
@@ -11,6 +11,9 @@ ok(_load_module('strict'), 'loads a valid module name');
 
 eval { _load_module('strict; die "boom"') };
 like($@, qr/bad Perl module name/, 'rejects unsafe module names');
+
+eval { _load_module(undef) };
+like($@, qr/bad Perl module name/, 'rejects undefined module names without warnings');
 
 eval { _load_module('strict', 999_999) };
 like($@, qr/strict version 999999 required|strict version 999999 required--this is only version/,


### PR DESCRIPTION
## Summary

Harden `Net::OpenSSH::ModuleLoader` module loading and version checks.

## Changes

- Validate module names before loading.
- Replace string `eval "require ..."` with non-string `require` on a module path.
- Use Perl's standard `$module->VERSION($version)` semantics for version requirements.
- Add regression tests for unsafe module names and version checks.
- Add the new test to `MANIFEST`.

Fixes #45.
Fixes #46.

## Testing

- `perl -Ilib -c lib/Net/OpenSSH/ModuleLoader.pm`
- `perl -Ilib t/module-loader.t`