### PR TITLE
Preserve MSCmd whitespace arguments

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -23,6 +23,7 @@ t/test_server_key.pub
 t/test_user_key
 t/test_user_key.pub
 t/known_hosts
+t/mscmd-quoting.t
 t/quoting.t
 t/uri.t
 examples/expect.pl

--- a/lib/Net/OpenSSH/ShellQuoter/MSCmd.pm
+++ b/lib/Net/OpenSSH/ShellQuoter/MSCmd.pm
@@ -13,6 +13,7 @@ sub quote {
         croak "can't quote newlines to pass through MS cmd.exe";
     }
     $arg =~ s/([()%!^"<>&|])/^$1/g;
+    $arg = qq|"$arg"| if $arg eq '' or $arg =~ /[ \t]/;
     $arg;
 }
 

--- a/t/mscmd-quoting.t
+++ b/t/mscmd-quoting.t
@@ -1,0 +1,20 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+
+use Test::More tests => 7;
+
+use Net::OpenSSH::ShellQuoter::MSCmd;
+
+my $q = Net::OpenSSH::ShellQuoter::MSCmd->new;
+
+is($q->quote('abc'), 'abc', 'plain arguments are unchanged');
+is($q->quote('a b'), '"a b"', 'space-containing arguments are grouped');
+is($q->quote("a\tb"), "\"a\tb\"", 'tab-containing arguments are grouped');
+is($q->quote(''), '""', 'empty arguments are preserved');
+is($q->quote('a&b'), 'a^&b', 'cmd metacharacters are escaped');
+is($q->quote('a & b'), '"a ^& b"', 'grouping is applied after escaping metacharacters');
+
+eval { $q->quote("a\n") };
+like($@, qr/can't quote newlines/, 'newlines are rejected');


### PR DESCRIPTION
## Summary

Fix `Net::OpenSSH::ShellQuoter::MSCmd` so it preserves empty arguments and arguments containing spaces or tabs.

## Changes

- Keep the existing cmd metacharacter escaping.
- Wrap empty and whitespace-containing arguments in double quotes after escaping.
- Add focused unit tests for plain, empty, whitespace, metacharacter, and newline cases.
- Add the new test file to `MANIFEST`.

Fixes #47.

## Testing

- `perl -Ilib -c lib/Net/OpenSSH/ShellQuoter/MSCmd.pm`
- `perl -Ilib t/mscmd-quoting.t`