### PR TITLE
Make spelling test author-only

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -24,6 +24,7 @@ t/test_user_key
 t/test_user_key.pub
 t/known_hosts
 t/quoting.t
+t/pod-spell.t
 t/uri.t
 examples/expect.pl
 examples/change_passwd.pl

--- a/t/pod-spell.t
+++ b/t/pod-spell.t
@@ -4,6 +4,9 @@ use strict;
 use warnings;
 use Test::More;
 
+plan skip_all => 'Author test. Set AUTHOR_TESTING to run.'
+    unless $ENV{AUTHOR_TESTING};
+
 eval "use Test::Spelling";
 plan skip_all => "Test::Spelling required for testing POD spelling" if $@;
 
@@ -40,8 +43,8 @@ my @ignore = ("Salvador", "Fandi\xf1o", "API", "CPAN", "GitHub",
               "Unix", "Ubuntu", "ssh", "cmd.exe", "BTW", "namespace",
               "IIRC", "Shellshock", "googling", "Gorwits", "netconf",
               "forwardings", "passphraseUses", "spawnAnother");
+push @ignore, qw(X11 didn doesn);
 
 local $ENV{LC_ALL} = 'C';
 add_stopwords(@ignore);
 all_pod_files_spelling_ok();
-


### PR DESCRIPTION
## Summary

Make the spelling test author-only and add the missing stopwords observed during review.

## Changes

- Skip `t/pod-spell.t` unless `AUTHOR_TESTING` is set.
- Add stopwords for `X11`, `didn`, and `doesn`.
- Add the tracked spelling test to `MANIFEST`.

Fixes #52.

## Testing

- `perl -Ilib t/pod-spell.t`
- `AUTHOR_TESTING=1 perl -Ilib t/pod-spell.t`