### PR TITLE
Test POD from source files

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -3,6 +3,7 @@ Makefile.PL
 MANIFEST
 README
 t/1_run.t
+t/2_pods.t
 lib/Net/OpenSSH.pm
 lib/Net/OpenSSH/Constants.pm
 lib/Net/OpenSSH/ConnectionCache.pm

--- a/t/2_pods.t
+++ b/t/2_pods.t
@@ -1,6 +1,7 @@
 #!/usr/bin/perl
 
 use strict;
+use warnings;
 use Test::More;
 
 eval "use Test::Pod 1.00";

--- a/t/2_pods.t
+++ b/t/2_pods.t
@@ -6,4 +6,4 @@ use Test::More;
 eval "use Test::Pod 1.00";
 plan skip_all => "Test::Pod 1.00 required for testing POD" if $@;
 
-all_pod_files_ok( all_pod_files( qw(blib) ) );
+all_pod_files_ok( all_pod_files( qw(lib) ) );


### PR DESCRIPTION
## Summary

Change the POD test to validate source files under `lib` instead of generated/stale files under `blib`.

## Changes

- Run `all_pod_files` against `lib`.
- Add the tracked POD test to `MANIFEST`.

Fixes #51.

## Testing

- `perl -Ilib t/2_pods.t`