### PR TITLE
Ignore generated local artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,9 @@ MYMETA.yml
 Makefile
 Makefile.old
 t/sshd.log
+pod2htmd.tmp
+misquoted.txt
+test.dat
+.Rhistory
+examples/scp_any_log.pl
+examples/scp_pty.pl


### PR DESCRIPTION
## Summary

Add targeted ignore patterns for generated and local artifacts observed during test/documentation runs.

## Changes

- Ignore `pod2htmd.tmp` files anywhere in the tree.
- Ignore local diagnostic/test artifacts: `misquoted.txt`, `test.dat`, `.Rhistory`.
- Ignore local scratch example scripts currently present in working trees.

Fixes #53.

## Testing

- `git status --short` now shows only the `.gitignore` change on this branch.