### PR TITLE
Fix ctl_path length boundary

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -18,6 +18,7 @@ lib/Net/OpenSSH/ShellQuoter/MSCmd.pm
 lib/Net/OpenSSH/ShellQuoter/Chain.pm
 lib/Net/OpenSSH/ObjectRemote.pm
 t/common.pm
+t/ctl-path.t
 t/test_server_key
 t/test_server_key.pub
 t/test_user_key

--- a/lib/Net/OpenSSH.pm
+++ b/lib/Net/OpenSSH.pm
@@ -474,8 +474,9 @@ sub new {
         }
     }
 
-    if (defined $sizeof_sun_path and length $ctl_path > $sizeof_sun_path) {
-        $self->_master_fail($async, "ctl_path $ctl_path is too long (max permissible size for $^O is $sizeof_sun_path)");
+    if (defined $sizeof_sun_path and length $ctl_path >= $sizeof_sun_path) {
+        my $max_ctl_path = $sizeof_sun_path - 1;
+        $self->_master_fail($async, "ctl_path $ctl_path is too long (max permissible size for $^O is $max_ctl_path)");
         return $self;
     }
 

--- a/t/ctl-path.t
+++ b/t/ctl-path.t
@@ -1,0 +1,36 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+
+use Test::More;
+use Net::OpenSSH;
+
+my $sizeof_sun_path = ($^O eq 'linux' ? 108 :
+                       $^O =~ /bsd/i  ? 104 :
+                       $^O eq 'hpux'  ? 92  : undef);
+
+plan skip_all => "sun_path size is not known on $^O"
+    unless defined $sizeof_sun_path;
+
+plan tests => 3;
+
+sub ctl_path_of_length {
+    my $length = shift;
+    my $prefix = '/tmp/';
+    die "test prefix is too long" if length($prefix) >= $length;
+    return $prefix . ('x' x ($length - length($prefix)));
+}
+
+my $good = ctl_path_of_length($sizeof_sun_path - 1);
+my $bad = ctl_path_of_length($sizeof_sun_path);
+
+my $ssh = Net::OpenSSH->new(host => 'localhost', ctl_path => $good,
+                            connect => 0, strict_mode => 0);
+is($ssh->error + 0, 0, 'usable maximum ctl_path length is accepted');
+is(length($ssh->get_ctl_path), $sizeof_sun_path - 1, 'accepted ctl_path has expected length');
+
+$ssh = Net::OpenSSH->new(host => 'localhost', ctl_path => $bad,
+                         connect => 0, strict_mode => 0);
+like($ssh->error, qr/max permissible size for \Q$^O\E is @{[$sizeof_sun_path - 1]}/,
+     'ctl_path requiring an extra NUL byte is rejected');

--- a/t/ctl-path.t
+++ b/t/ctl-path.t
@@ -26,11 +26,13 @@ my $good = ctl_path_of_length($sizeof_sun_path - 1);
 my $bad = ctl_path_of_length($sizeof_sun_path);
 
 my $ssh = Net::OpenSSH->new(host => 'localhost', ctl_path => $good,
-                            connect => 0, strict_mode => 0);
+                            connect => 0, strict_mode => 0,
+                            ssh_version => 'OpenSSH_10.0');
 is($ssh->error + 0, 0, 'usable maximum ctl_path length is accepted');
 is(length($ssh->get_ctl_path), $sizeof_sun_path - 1, 'accepted ctl_path has expected length');
 
 $ssh = Net::OpenSSH->new(host => 'localhost', ctl_path => $bad,
-                         connect => 0, strict_mode => 0);
+                         connect => 0, strict_mode => 0,
+                         ssh_version => 'OpenSSH_10.0');
 like($ssh->error, qr/max permissible size for \Q$^O\E is @{[$sizeof_sun_path - 1]}/,
      'ctl_path requiring an extra NUL byte is rejected');


### PR DESCRIPTION
## Summary

Reject control socket paths that fill `sun_path` without room for the required terminating NUL byte.

## Changes

- Treat `sizeof(sun_path) - 1` as the maximum usable path length.
- Update the error message to report the usable maximum.
- Add a boundary regression test for accepted and rejected lengths.
- Add the new test to `MANIFEST`.

Fixes #44.

## Testing

- `perl -Ilib -c lib/Net/OpenSSH.pm`
- `perl -Ilib t/ctl-path.t`