### PR TITLE
Handle _io3 syscall return states

### DIFF
--- a/lib/Net/OpenSSH.pm
+++ b/lib/Net/OpenSSH.pm
@@ -1865,7 +1865,7 @@ sub _io3 {
                         _debug "stdout, bytes read: ", $read, " at offset $offset";
                         $read and $debug & 128 and _hexdump substr $bout, $offset;
                     }
-                    unless ($read or grep $! == $_, @retriable) {
+                    unless (defined($read) ? $read : grep $! == $_, @retriable) {
                         close $out;
                         undef $cout;
                         $recalc_vecs = 1;
@@ -1874,7 +1874,7 @@ sub _io3 {
                 if ($cerr and vec($rv1, $fnoerr, 1)) {
                     my $read = sysread($err, $berr, 20480, length($berr));
                     $debug and $debug & 64 and _debug "stderr, bytes read: ", $read;
-                    unless ($read or grep $! == $_, @retriable) {
+                    unless (defined($read) ? $read : grep $! == $_, @retriable) {
                         close $err;
                         undef $cerr;
                         $recalc_vecs = 1;
@@ -1895,7 +1895,7 @@ sub _io3 {
                         }
                         # fallback when stdin queue is exhausted
                     }
-                    elsif (grep $! == $_, @retriable) {
+                    elsif (!defined($written) and grep $! == $_, @retriable) {
                         next FAST;
                     }
                     close $in unless $keep_in_open;


### PR DESCRIPTION
## Summary

Make `_io3` distinguish zero-byte successful returns from errno-bearing syscall failures.

## Changes

- Treat `sysread` returning `0` as EOF without consulting stale `$!`.
- Consult `$!` for `sysread` only when the return value is `undef`.
- Consult `$!` for `syswrite` only when the return value is `undef`.

Fixes #39.
Fixes #40.

## Testing

- `perl -Ilib -c lib/Net/OpenSSH.pm`
- `perl -Ilib t/1_run.t`