### PR TITLE
Handle master pty allocation failure

### DIFF
--- a/lib/Net/OpenSSH.pm
+++ b/lib/Net/OpenSSH.pm
@@ -983,6 +983,7 @@ sub _master_start {
     if ($use_pty) {
         _load_module('IO::Pty');
         $self->{_mpty} = $mpty = IO::Pty->new;
+        $mpty or return $self->_master_fail($async, "unable to allocate pseudo-tty: $!");
     }
 
     push @master_opts, -o => "PreferredAuthentications=$pref_auths"


### PR DESCRIPTION
## Summary

Fail master startup immediately when `IO::Pty->new` cannot allocate a pseudo-tty.

## Changes

- Check the return value from `IO::Pty->new` in `_master_start`.
- Report a clear master failure instead of continuing without the pty and later producing a generic connection/login failure.

Fixes #42.

## Testing

- `perl -Ilib -c lib/Net/OpenSSH.pm`
- `perl -Ilib t/1_run.t`