### PR TITLE
Quote rsync transport safely

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -24,6 +24,7 @@ t/test_user_key
 t/test_user_key.pub
 t/known_hosts
 t/quoting.t
+t/rsync-quote.t
 t/uri.t
 examples/expect.pl
 examples/change_passwd.pl

--- a/lib/Net/OpenSSH.pm
+++ b/lib/Net/OpenSSH.pm
@@ -640,11 +640,9 @@ sub _make_scp_call {
 sub _rsync_quote {
     my ($self, @args) = @_;
     for (@args) {
-	if (/['"\s]/) {
-	    s/"/""/g;
-	    $_ = qq|"$_"|;
-	}
-	s/%/%%/;
+        s/%/%%/g;
+        s/'/'\\''/g;
+        $_ = qq|'$_'|;
     }
     wantarray ? @args : join(' ', @args);
 }

--- a/t/rsync-quote.t
+++ b/t/rsync-quote.t
@@ -1,0 +1,15 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+
+use Test::More tests => 5;
+use Net::OpenSSH;
+
+is(Net::OpenSSH->_rsync_quote('ssh'), q{'ssh'}, 'plain arguments are quoted');
+is(Net::OpenSSH->_rsync_quote('a b'), q{'a b'}, 'space-containing arguments are quoted');
+is(Net::OpenSSH->_rsync_quote(q{a'b}), q{'a'\''b'}, 'single quotes are escaped');
+is(Net::OpenSSH->_rsync_quote('a%b%c'), q{'a%%b%%c'}, 'all percent characters are doubled');
+
+my @quoted = Net::OpenSSH->_rsync_quote('ssh', '-S', '/tmp/a b');
+is_deeply(\@quoted, [q{'ssh'}, q{'-S'}, q{'/tmp/a b'}], 'list context returns quoted arguments');


### PR DESCRIPTION
## Summary

Make rsync transport command quoting safe for POSIX shell command strings.

## Changes

- Quote every transport argument with POSIX single-quote escaping.
- Preserve embedded single quotes.
- Double all `%` characters, not just the first one.
- Add focused regression tests for whitespace, single quotes, percent escaping, and list context.
- Add the new test to `MANIFEST`.

Fixes #41.

## Testing

- `perl -Ilib -c lib/Net/OpenSSH.pm`
- `perl -Ilib t/rsync-quote.t`