### PR TITLE
Quote command args in setenv example

### DIFF
--- a/examples/setenv_and_exec.pl
+++ b/examples/setenv_and_exec.pl
@@ -25,7 +25,6 @@ for my $env (@envs) {
     push @cmds, "export " . $ssh->shell_quote($env) .'='.$ssh->shell_quote($ENV{$env})
 }
 
-my $cmd = join('&&', @cmds, '('. join(' ', @ARGV) .')');
+my $cmd = join('&&', @cmds, '('. join(' ', map $ssh->shell_quote($_), @ARGV) .')');
 warn "remote command: $cmd\n";
 $ssh->system($cmd);
-


### PR DESCRIPTION
## Summary

Quote the user command and arguments in `examples/setenv_and_exec.pl` before building the remote shell command.

## Changes

- Apply `$ssh->shell_quote` to every element of `@ARGV`.
- Preserve the existing environment export behavior.

Fixes #54.

## Testing

- `perl -Ilib -c examples/setenv_and_exec.pl`